### PR TITLE
Scoped DNR rules & privacy hardening (v1.16.0–v1.23.0); resolves both security review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,5 +103,55 @@ _Note that any version might include a number of stylistic changes, which are of
 	<br>- Fixed extension breaking media elements when autoplay is disabled.
 	- v1.15.2:
 	<br>- Rolled back a change to fix the Paramount+ player (again).
-	- v1.15.3:
-	<br>- Mitigated a frequent error message in the Firefox's multiprocess browser console.
+
+- **v1.16.0**:
+<br>- Made the "cookies" permission optional; it's now requested only when enabling "Send cookies to media requests" for a site.
+<br>- Removed the "scripting" permission; the popup no longer injects code into pages, frames report the cross-origin media hosts they embed on their own.
+<br>- Replaced the rule that relaxed CORS for every media response on the web with rules scoped to each (page -> media domain) pair, created on demand and removed when no tab needs them anymore. Same-origin media is no longer modified at all.
+<br>- Limited the cookie workaround to same-site media requests only, fixed its malformed cookie header value, and allowed multiple per-site cookie rules to coexist.
+<br>- Cookie rules now refresh when the site's cookies change, and are removed when the permission is revoked.
+<br>- The temporary "session" multiplier now lives in memory-only storage and is forgotten when the browser closes (values saved on disk by older versions are migrated).
+<br>- Added a Privacy panel to the options page, with the cookies permission status and a "Forget per-site settings" button; "Clear all settings" now also clears session data.
+<br>- Fixed bug where clicking a page before any media loaded could crash the content script.
+<br>- Debug logs are now gated behind a flag in every context.
+
+- **v1.17.0**:
+<br>- Added a strict Content Security Policy to the popup and options pages.
+<br>- The extension now shares only the minimal data (tab url + exclusion flag) with its content scripts instead of the whole settings object.
+<br>- Hostnames received over internal messages are now validated before they can reach any header rule.
+<br>- Fixed the permission prompt's hostname reduction to use true subdomain relations (the old logic could merge unrelated domains like `evilsite.com` into `site.com`), and bare domains now get their exact-origin permission pattern too.
+<br>- Cookie rule installation now fails closed if the browser rejects it.
+<br>- Cross-origin media that hasn't started loading is no longer force-restarted, and the extension no longer waits forever on media that errors out.
+<br>- Fixed the add-on's icon size declarations.
+
+- **v1.18.0**:
+<br>- Cookie values re-attached by the workaround are now filtered to safe characters, so a malformed cookie can never inject header content.
+<br>- The hard volume limit now also clamps already-saved volumes, so lowering the limit reins in older, higher values.
+<br>- Fixed bug where `file://` pages (and pages without a hostname) were wrongly treated as excluded.
+<br>- Fixed bug where the extension could throw on websites that already control their media with their own WebAudio graph; such pages are now left completely alone.
+<br>- Audio contexts now also resume on key presses, not only on clicks.
+
+- **v1.19.0**:
+<br>- Fixed bug where header rules from a previous browser session could linger after a restart; the extension now re-syncs its rules on every boot (re-associating them with open tabs, removing unneeded ones and purging stale cookie rules).
+<br>- Made the registrable-domain computation public-suffix aware (`co.uk`, `com.au`, ...), so the cookie workaround and the permission prompts can no longer collapse to an over-broad TLD scope; IPv4 addresses are handled too.
+<br>- Volume updates are now broadcast only when the relevant settings actually change, reducing internal message noise.
+
+- **v1.20.0**:
+<br>- Limited the "Send cookies to media requests" workaround to the default container: container tabs neither create nor remove cookie rules, so cookies can never cross Multi-Account Container walls. The context menu item is labelled accordingly.
+<br>- Volume changes now use a short ramp instead of an instant jump, so there are no audible pops when the multiplier changes mid-playback.
+
+- **v1.21.0**:
+<br>- Fixed bug where media inside cross-origin iframes would not get boosted (the scoped rules used the top page's hostname instead of the frame's own).
+<br>- Added a confirmation before "enable it for all websites" requests access to all websites.
+<br>- Slider drags are now coalesced into a single update instead of pinging every open tab on each movement.
+
+- **v1.22.0**:
+<br>- Fixed bug where players that swap a media element's source to another cross-origin host (playlists, CDN fallbacks) would stop working; the new scoped rule is requested when the source changes.
+<br>- The permission prompt now offers only hosts that actually serve cross-origin media, never asking for more access than the page needs.
+<br>- Raised the cap of simultaneous scoped rules from 300 to 1000, so heavy multi-tab sessions don't lose rules.
+
+- **v1.23.0**:
+<br>- Fixed bug where cross-origin media carrying its URL in a `<source>` child would connect silenced instead of being boosted.
+<br>- Cross-origin media is now always fetched with its scoped rule already in place, so tainted (silenced) media can no longer occur.
+<br>- Tightened the popup and options Content Security Policy further (workers, media, manifests and frames are now forbidden; none of them are used).
+<br>- Fixed bug where opening the popup instantly on a fresh page could wrongly show "No media detected" while the page was still loading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,53 +105,52 @@ _Note that any version might include a number of stylistic changes, which are of
 	<br>- Rolled back a change to fix the Paramount+ player (again).
 
 - **v1.16.0**:
-<br>- Made the "cookies" permission optional; it's now requested only when enabling "Send cookies to media requests" for a site.
-<br>- Removed the "scripting" permission; the popup no longer injects code into pages, frames report the cross-origin media hosts they embed on their own.
-<br>- Replaced the rule that relaxed CORS for every media response on the web with rules scoped to each (page -> media domain) pair, created on demand and removed when no tab needs them anymore. Same-origin media is no longer modified at all.
-<br>- Limited the cookie workaround to same-site media requests only, fixed its malformed cookie header value, and allowed multiple per-site cookie rules to coexist.
-<br>- Cookie rules now refresh when the site's cookies change, and are removed when the permission is revoked.
-<br>- The temporary "session" multiplier now lives in memory-only storage and is forgotten when the browser closes (values saved on disk by older versions are migrated).
-<br>- Added a Privacy panel to the options page, with the cookies permission status and a "Forget per-site settings" button; "Clear all settings" now also clears session data.
-<br>- Fixed bug where clicking a page before any media loaded could crash the content script.
-<br>- Debug logs are now gated behind a flag in every context.
+<br>- Made the "cookies" permission optional; it's now requested only when a site needs it.
+<br>- Removed the "scripting" permission; the popup no longer injects code into pages.
+<br>- Scoped the CORS relaxation to each (page -> media domain) pair instead of all media responses.
+<br>- Same-origin media is no longer modified at all.
+<br>- Limited the cookie workaround to same-site media requests and fixed its malformed header value.
+<br>- Session multiplier now lives in memory-only storage (old on-disk values are migrated).
+<br>- Added a Privacy panel and a "Forget per-site settings" button to the options.
+<br>- Fixed a crash when clicking a page before any media loaded.
 
 - **v1.17.0**:
 <br>- Added a strict Content Security Policy to the popup and options pages.
-<br>- The extension now shares only the minimal data (tab url + exclusion flag) with its content scripts instead of the whole settings object.
-<br>- Hostnames received over internal messages are now validated before they can reach any header rule.
-<br>- Fixed the permission prompt's hostname reduction to use true subdomain relations (the old logic could merge unrelated domains like `evilsite.com` into `site.com`), and bare domains now get their exact-origin permission pattern too.
-<br>- Cookie rule installation now fails closed if the browser rejects it.
-<br>- Cross-origin media that hasn't started loading is no longer force-restarted, and the extension no longer waits forever on media that errors out.
+<br>- Content scripts now receive only the tab url and the exclusion flag, not the whole settings.
+<br>- Hostnames are now validated before reaching any header rule.
+<br>- Fixed the permission prompt merging unrelated domains (e.g. `evilsite.com` into `site.com`).
+<br>- Bare domains now get their exact-origin permission pattern too.
+<br>- Cross-origin media that hasn't started loading is no longer force-restarted.
 <br>- Fixed the add-on's icon size declarations.
 
 - **v1.18.0**:
-<br>- Cookie values re-attached by the workaround are now filtered to safe characters, so a malformed cookie can never inject header content.
-<br>- The hard volume limit now also clamps already-saved volumes, so lowering the limit reins in older, higher values.
-<br>- Fixed bug where `file://` pages (and pages without a hostname) were wrongly treated as excluded.
-<br>- Fixed bug where the extension could throw on websites that already control their media with their own WebAudio graph; such pages are now left completely alone.
-<br>- Audio contexts now also resume on key presses, not only on clicks.
+<br>- Cookie values re-attached by the workaround are now filtered to safe characters.
+<br>- The hard limit now also clamps already-saved volumes.
+<br>- Fixed `file://` pages being wrongly treated as excluded.
+<br>- Websites that own their media's WebAudio graph are now left alone.
+<br>- Audio contexts now also resume on key presses.
 
 - **v1.19.0**:
-<br>- Fixed bug where header rules from a previous browser session could linger after a restart; the extension now re-syncs its rules on every boot (re-associating them with open tabs, removing unneeded ones and purging stale cookie rules).
-<br>- Made the registrable-domain computation public-suffix aware (`co.uk`, `com.au`, ...), so the cookie workaround and the permission prompts can no longer collapse to an over-broad TLD scope; IPv4 addresses are handled too.
-<br>- Volume updates are now broadcast only when the relevant settings actually change, reducing internal message noise.
+<br>- Header rules from previous sessions are now re-synced or pruned on every boot.
+<br>- Made domain scoping public-suffix aware (`co.uk`, `com.au`, ...) and IPv4-safe.
+<br>- Volume updates are now broadcast only when the settings actually change.
 
 - **v1.20.0**:
-<br>- Limited the "Send cookies to media requests" workaround to the default container: container tabs neither create nor remove cookie rules, so cookies can never cross Multi-Account Container walls. The context menu item is labelled accordingly.
-<br>- Volume changes now use a short ramp instead of an instant jump, so there are no audible pops when the multiplier changes mid-playback.
+<br>- The cookie workaround is now limited to the default container (container-safe).
+<br>- Volume changes now ramp smoothly instead of jumping (no audible pops).
 
 - **v1.21.0**:
-<br>- Fixed bug where media inside cross-origin iframes would not get boosted (the scoped rules used the top page's hostname instead of the frame's own).
-<br>- Added a confirmation before "enable it for all websites" requests access to all websites.
-<br>- Slider drags are now coalesced into a single update instead of pinging every open tab on each movement.
+<br>- Fixed media inside cross-origin iframes not getting boosted.
+<br>- Added a confirmation before requesting access to all websites.
+<br>- Slider drags are now coalesced into a single update.
 
 - **v1.22.0**:
-<br>- Fixed bug where players that swap a media element's source to another cross-origin host (playlists, CDN fallbacks) would stop working; the new scoped rule is requested when the source changes.
-<br>- The permission prompt now offers only hosts that actually serve cross-origin media, never asking for more access than the page needs.
-<br>- Raised the cap of simultaneous scoped rules from 300 to 1000, so heavy multi-tab sessions don't lose rules.
+<br>- Fixed players that swap a media's source to another cross-origin host.
+<br>- The permission prompt now offers only hosts that actually serve cross-origin media.
+<br>- Raised the scoped-rule cap from 300 to 1000.
 
 - **v1.23.0**:
-<br>- Fixed bug where cross-origin media carrying its URL in a `<source>` child would connect silenced instead of being boosted.
-<br>- Cross-origin media is now always fetched with its scoped rule already in place, so tainted (silenced) media can no longer occur.
-<br>- Tightened the popup and options Content Security Policy further (workers, media, manifests and frames are now forbidden; none of them are used).
-<br>- Fixed bug where opening the popup instantly on a fresh page could wrongly show "No media detected" while the page was still loading.
+<br>- Fixed cross-origin media in a `<source>` child connecting silenced instead of boosted.
+<br>- Cross-origin media is now always fetched with its scoped rule already in place.
+<br>- Tightened the popup/options CSP further (no workers, media, manifests or frames).
+<br>- Fixed a false "No media detected" message when opening the popup on a fresh page.

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
 	"manifest_version": 3,
 	"name": "Better Volume Booster",
-	"version": "1.15.3",
-	"description": "Volume booster firefox extension that remembers your choices.",
+	"version": "1.23.0",
+	"description": "Volume booster firefox extension that remembers your choices. Privacy-focused: no telemetry, no external requests, minimal permissions, all data stays on your device",
 
 	"icons": {
 		"48": "images/icon-512.png",
@@ -18,37 +18,44 @@
 		"browser_style": false
 	},
 	"background": {
-		"scripts": ["scripts/utils.js", "scripts/background.js"]
+		"scripts": [
+			"scripts/utils.js",
+			"scripts/background.js"
+		]
 	},
 	"content_scripts": [
 		{
 			"matches": [
 				"<all_urls>"
 			],
-			"js": ["scripts/utils.js", "scripts/content.js"],
+			"js": [
+				"scripts/content.js"
+			],
 			"run_at": "document_start",
 			"all_frames": true,
 			"match_about_blank": true
 		}
 	],
-
 	"optional_permissions": [
-		"<all_urls>"
+		"<all_urls>",
+		"cookies"
 	],
 	"permissions": [
 		"declarativeNetRequestWithHostAccess",
 		"storage",
-		"scripting",
-		"cookies",
 		"contextMenus"
 	],
-
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "VolumeBoosterWithoutDementia@zWolfrost.github.com",
 			"data_collection_permissions": {
-				"required": ["none"]
+				"required": [
+					"none"
+				]
 			}
 		}
+	},
+	"content_security_policy": {
+		"extension_pages": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'none'; base-uri 'none'; form-action 'none'; worker-src 'none'; media-src 'none'; manifest-src 'none'; frame-src 'none'"
 	}
 }

--- a/pages/popup.html
+++ b/pages/popup.html
@@ -64,7 +64,7 @@
 		</div>
 
 		<div id="no-media-detected-message" class="option message hidden">
-			No media element detected...
+			No cross-origin media detected (same-origin media needs no extra permissions)...
 		</div>
 
 		<div id="excluded-hostname-message" class="option message hidden">

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,15 +1,43 @@
 "use strict";
 
+const DEBUG = false;
+const log = (...args) => { if (DEBUG) console.log(...args); };
+
 const HOSTNAME_TITLE_NORMAL_ID = "hostname-title";
-const EXCLUDE_HOSTNAME_CHECKBOX_ID = "exclude-hostname"
-const SEND_COOKIES_CHECKBOX_ID = "send-cookies"
+const EXCLUDE_HOSTNAME_CHECKBOX_ID = "exclude-hostname";
+const SEND_COOKIES_CHECKBOX_ID = "send-cookies";
+
+/* Hard cap on simultaneously active CORS-relaxation rules. */
+const MAX_CORS_RULES = 1000;
+
+// registrableDomain comes from utils.js (public-suffix aware)
+const safeHostname = url => { try { return new URL(url).hostname; } catch { return null; } };
 
 
-// CONTEXT MENU SETUP
+/* ------------------------------------------------------------------ */
+/* In-memory, per-tab bookkeeping. Nothing here is ever persisted:     */
+/* it is forgotten as soon as the tab navigates away or closes, or the */
+/* browser session ends.                                               */
+/* ------------------------------------------------------------------ */
+const mediaSourcesByTab = new Map(); // tabId -> Set(hostname)   (for the popup's permission prompt)
+const tabCorsKeys       = new Map(); // tabId -> Set(pairKey)    (which CORS rules this tab caused)
+const tabHostnames      = new Map(); // tabId -> hostname
+
+const corsRules = new Map();         // "initiator -> domain" -> {id, tabs:Set}
+let nextCorsRuleId = 1000;
+
+const cookieRuleIds = new Map();     // hostname -> ruleId
+let nextCookieRuleId = 2;
+
+
+/* ------------------------------------------------------------------ */
+/* CONTEXT MENU SETUP (unchanged user-facing behaviour)                */
+/* ------------------------------------------------------------------ */
 browser.contextMenus.onShown.addListener(async (info, tab) => {
 	if (!tab.url) return;
 
-	const hostname = new URL(tab.url).hostname;
+	const hostname = safeHostname(tab.url);
+	if (!hostname) return;
 	const storage = await getStorage(hostname);
 
 	await browser.contextMenus.create({
@@ -30,7 +58,7 @@ browser.contextMenus.onShown.addListener(async (info, tab) => {
 
 	await browser.contextMenus.create({
 		id: SEND_COOKIES_CHECKBOX_ID,
-		title: "Send cookies to media requests",
+		title: "Send cookies to media requests (default container only)",
 		type: "checkbox",
 		contexts: ["action"],
 		checked: storage[hostname].sendCookiesInMediaRequests
@@ -43,7 +71,8 @@ browser.contextMenus.onHidden.addListener(() => browser.contextMenus.removeAll()
 
 
 browser.contextMenus.onClicked.addListener(async (info, tab) => {
-	const hostname = new URL(tab.url).hostname;
+	const hostname = safeHostname(tab.url);
+	if (!hostname) return;
 	const storage = await getStorage(hostname);
 
 	let propertyName = {
@@ -51,73 +80,296 @@ browser.contextMenus.onClicked.addListener(async (info, tab) => {
 		[SEND_COOKIES_CHECKBOX_ID]: "sendCookiesInMediaRequests"
 	}[info.menuItemId]
 
-	await setStorage({ [hostname]: { [propertyName]: !storage[hostname][propertyName] } });
+	const newValue = !storage[hostname][propertyName];
 
-	await DNRsetupCORS(await getStorage());
-	await DNRsetupCookies(hostname, await getStorage(hostname));
+	// "Send cookies" is now backed by an *optional* permission: ask for it
+	// (user gesture = this click) only when the feature is being enabled.
+	if (propertyName === "sendCookiesInMediaRequests" && newValue) {
+		const granted = await ensureCookiesPermission(tab.id);
+		if (!granted) return; // setting stays off; options page explains why
+	}
+
+	await setStorage({ [hostname]: { [propertyName]: newValue } });
+
+	await DNRsetupCookies(hostname, (await getStorage(hostname))[hostname], tab.cookieStoreId);
 
 	browser.tabs.reload(tab.id);
 });
 
+async function ensureCookiesPermission(tabId) {
+	if (await browser.permissions.contains({permissions: ["cookies"]})) return true;
 
-browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-	if (changeInfo.status === "complete" && tab.url) {
-		browser.tabs.sendMessage(tabId, {action: "updateVolume", url: tab.url});
+	let granted = false;
+	try {
+		// This runs inside the context-menu click, i.e. a user gesture.
+		granted = await browser.permissions.request({permissions: ["cookies"]});
 	}
-});
-
-
-// DECLARATIVE NET REQUESTS RULES SETUP
-browser.runtime.onMessage.addListener(async (message, sender) => {
-	const url = sender.tab.url;
-	const hostname = new URL(url).hostname;
-	const storage = await getStorage(hostname);
-
-	if (message.action == "updateRequests") {
-		await DNRsetupCookies(hostname, storage);
+	catch (error) {
+		log("cookies permission request failed:", error);
 	}
 
-	return {url: url, storage: storage};
-});
-
-
-async function DNRsetupCORS(storage) {
-	const excludedHostnames = Object.keys(storage).filter(host => storage[host].excluded);
-
-	await browser.declarativeNetRequest.updateDynamicRules({
-		removeRuleIds: [1],
-		addRules: [{
-			"id": 1,
-			"priority": 1,
-			"action": {
-				"type": "modifyHeaders",
-				"responseHeaders": [{
-					"header": "Access-Control-Allow-Origin",
-					"operation": "set",
-					"value": "*"
-				}]
-			},
-			"condition": {
-				"resourceTypes": ["media"],
-				"excludedInitiatorDomains": excludedHostnames
-			}
-		}]
-	});
-
-	console.log("CORS DNR rules updated with excluded domains: ", excludedHostnames);
+	if (!granted) {
+		// Denied or impossible: explain what happened on the options page.
+		try {
+			await browser.tabs.create({url: browser.runtime.getURL("pages/options.html") + "#cookies-permission"});
+		} catch {}
+	}
+	return granted;
 }
 
-async function DNRsetupCookies(hostname, storage) {
-	if (!storage[hostname].excluded && storage[hostname].sendCookiesInMediaRequests) {
-		const domain = hostname.split(".").slice(-2).join(".");
+browser.permissions.onRemoved.addListener(change => {
+	if (change.permissions?.includes("cookies")) removeAllCookieRules();
+});
 
-		const cookies = await browser.cookies.getAll({domain: domain});
-		const cookieString = '"' + cookies.map(cookie => `${cookie.name}=${cookie.value}`).join("; ") + '"'
 
+/* ------------------------------------------------------------------ */
+/* TAB LIFECYCLE: forget per-tab data as early as possible             */
+/* ------------------------------------------------------------------ */
+browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+	if (changeInfo.status === "complete" && tab.url) {
+		browser.tabs.sendMessage(tabId, {action: "updateVolume", url: tab.url}).catch(() => {});
+	}
+
+	// Main-frame navigation to another host: drop everything we remembered
+	// about the previous document (scoped CORS rules + media source list).
+	if (changeInfo.status === "loading" && tab.url) {
+		const hostname = safeHostname(tab.url);
+		const previous = tabHostnames.get(tabId);
+		if (hostname && previous && hostname !== previous) {
+			dropTabCorsRules(tabId);
+			mediaSourcesByTab.delete(tabId);
+		}
+		if (hostname) tabHostnames.set(tabId, hostname);
+	}
+});
+
+browser.tabs.onRemoved.addListener(tabId => {
+	dropTabCorsRules(tabId);
+	mediaSourcesByTab.delete(tabId);
+	tabHostnames.delete(tabId);
+});
+
+
+/* ------------------------------------------------------------------ */
+/* MESSAGES FROM CONTENT SCRIPTS / PAGES                               */
+/* ------------------------------------------------------------------ */
+browser.runtime.onMessage.addListener(async (message, sender) => {
+	switch (message.action) {
+		// A content script booted up: give it its url + the only setting it
+		// needs up front (the exclusion flag), and make sure the (scoped,
+		// optional) cookie rule for this host is in place. The full settings
+		// object never leaves the background context.
+		case "updateRequests": {
+			const url = sender.tab?.url;
+			if (!url) return {};
+			const hostname = safeHostname(url);
+			if (hostname === null) return {url: url, excluded: true};
+			const storage = await getStorage(hostname);
+
+			DNRsetupCookies(hostname, storage[hostname], sender.tab.cookieStoreId).catch(() => {});
+
+			return {url: url, excluded: !!storage[hostname].excluded};
+		}
+
+		// A content script found cross-origin media and needs the CORS
+		// relaxation *only* for this (page -> media domain) pair.
+		case "ensureCors": {
+			const tabId = sender.tab?.id;
+			const initiator = message.initiator;
+			const domain = message.domain;
+			if (!tabId || !isValidHostname(initiator) || !isValidHostname(domain)) return {ok: false};
+
+			const storage = await getStorage(initiator);
+			if (storage[initiator].excluded) return {ok: false};
+
+			try {
+				await ensureCorsRule(initiator, domain, tabId);
+				return {ok: true};
+			}
+			catch (error) {
+				log("ensureCors failed:", error);
+				return {ok: false};
+			}
+		}
+
+		// Content scripts (every frame) report the cross-origin hosts they
+		// embed media from, so the popup can offer scoped host permissions.
+		case "reportMediaSources": {
+			const tabId = sender.tab?.id;
+			if (!tabId) return {};
+			let set = mediaSourcesByTab.get(tabId);
+			if (!set) { set = new Set(); mediaSourcesByTab.set(tabId, set); }
+			for (const hostname of (message.hostnames ?? [])) {
+				if (isValidHostname(hostname)) set.add(hostname);
+			}
+			return {};
+		}
+
+		case "getMediaSources": {
+			return {hostnames: Array.from(mediaSourcesByTab.get(message.tabId) ?? [])};
+		}
+
+		// Effective (session > local > global) settings for a tab.
+		case "getEffective": {
+			const hostname = safeHostname(message.url);
+			if (hostname === null) return {excluded: true};
+			const storage = await getStorage(hostname);
+			if (storage[hostname].excluded) return {excluded: true};
+			const options = storage.session.url == message.url ? storage.session : storage[hostname];
+			return {excluded: false, volume: options.volume, mono: options.mono};
+		}
+	}
+});
+
+
+/* Keep every tab in sync when settings change (including the RAM-only
+   session storage, which content scripts can't observe themselves). */
+async function broadcastVolumeUpdate() {
+	const tabs = await browser.tabs.query({});
+	for (const tab of tabs) {
+		if (tab.url) browser.tabs.sendMessage(tab.id, {action: "updateVolume", url: tab.url}).catch(() => {});
+	}
+}
+
+// Slider drags produce bursts of storage writes; coalesce them into a single
+// broadcast so N tabs aren't pinged on every input event.
+let broadcastTimer = null;
+function scheduleBroadcast() {
+	if (broadcastTimer) return;
+	broadcastTimer = setTimeout(() => {
+		broadcastTimer = null;
+		broadcastVolumeUpdate();
+	}, 100);
+}
+
+browser.storage.local.onChanged.addListener(scheduleBroadcast);
+// Session-area changes only matter to tabs when the actual "session"
+// multiplier object changed; don't spam every tab for other keys.
+if (browser.storage.session) {
+	browser.storage.session.onChanged.addListener(changes => {
+		if (changes && "session" in changes) scheduleBroadcast();
+	});
+}
+
+
+/* ------------------------------------------------------------------ */
+/* DECLARATIVE NET REQUEST RULES                                       */
+/*                                                                     */
+/* PRIVACY MODEL (v1.16):                                              */
+/*  - CORS is no longer relaxed for *every* media response on the web. */
+/*    A rule is created per (initiator page -> media domain) pair, on  */
+/*    demand, and only while a tab that needed it is still open.       */
+/*  - Cookie injection (opt-in per subdomain, optional permission) is  */
+/*    restricted to same-site media requests: both the requester and   */
+/*    the destination must be the configured domain. Cookie values are */
+/*    kept inside in-memory DNR rules only, never in extension storage */
+/*    and never sent anywhere else.                                    */
+/* ------------------------------------------------------------------ */
+
+async function ensureCorsRule(initiator, domain, tabId) {
+	const key = `${initiator} -> ${domain}`;
+	let record = corsRules.get(key);
+
+	if (!record) {
+		// Evict the oldest rule if we hit the cap.
+		if (corsRules.size >= MAX_CORS_RULES) {
+			const oldestKey = corsRules.keys().next().value;
+			const oldest = corsRules.get(oldestKey);
+			corsRules.delete(oldestKey);
+			for (const otherTab of oldest.tabs) tabCorsKeys.get(otherTab)?.delete(oldestKey);
+			await browser.declarativeNetRequest.updateDynamicRules({removeRuleIds: [oldest.id]});
+		}
+
+		const id = nextCorsRuleId++;
 		await browser.declarativeNetRequest.updateDynamicRules({
-			removeRuleIds: [2],
 			addRules: [{
-				"id": 2,
+				"id": id,
+				"priority": 1,
+				"action": {
+					"type": "modifyHeaders",
+					"responseHeaders": [{
+						"header": "Access-Control-Allow-Origin",
+						"operation": "set",
+						"value": "*"
+					}]
+				},
+				"condition": {
+					"resourceTypes": ["media"],
+					"initiatorDomains": [initiator],
+					"requestDomains": [domain]
+				}
+			}]
+		});
+
+		record = {id, tabs: new Set()};
+		corsRules.set(key, record);
+		log("Scoped CORS rule added:", key);
+	}
+
+	record.tabs.add(tabId);
+	tabHostnames.set(tabId, initiator);
+	let keys = tabCorsKeys.get(tabId);
+	if (!keys) { keys = new Set(); tabCorsKeys.set(tabId, keys); }
+	keys.add(key);
+}
+
+function dropTabCorsRules(tabId) {
+	const keys = tabCorsKeys.get(tabId);
+	if (!keys) return;
+	tabCorsKeys.delete(tabId);
+
+	const removeRuleIds = [];
+	for (const key of keys) {
+		const record = corsRules.get(key);
+		if (!record) continue;
+		record.tabs.delete(tabId);
+		if (record.tabs.size === 0) {
+			corsRules.delete(key);
+			removeRuleIds.push(record.id);
+		}
+	}
+	if (removeRuleIds.length) {
+		browser.declarativeNetRequest.updateDynamicRules({removeRuleIds}).catch(() => {});
+		log("Scoped CORS rules removed for tab", tabId, removeRuleIds);
+	}
+}
+
+async function DNRsetupCookies(hostname, hostStorage, storeId = "firefox-default") {
+	if (!hostname || !hostStorage) return;
+
+	// Multi-Account Containers are a Firefox privacy boundary: cookie rules
+	// are built from the default cookie store and DNR cannot scope rules to a
+	// container, so container tabs neither create nor remove them - the
+	// workaround lives and dies with default-container contexts only.
+	if (storeId !== "firefox-default") return;
+
+	const hasPermission = await browser.permissions.contains({permissions: ["cookies"]});
+
+	if (!hostStorage.excluded && hostStorage.sendCookiesInMediaRequests && hasPermission) {
+		const domain = registrableDomain(hostname);
+
+		// Only RFC 6265-safe names/values may reach the header: this makes
+		// CRLF / delimiter injection through a hostile cookie impossible.
+		const COOKIE_NAME = /^[!#$%&'*+\-.^_`|~0-9a-zA-Z]+$/;
+		const COOKIE_VALUE = /^[!#$%&'*+\-.^_`|~0-9a-zA-Z:\/]*$/;
+		const cookies = await browser.cookies.getAll({domain: domain});
+		const cookieString = cookies
+			.filter(cookie => COOKIE_NAME.test(cookie.name) && COOKIE_VALUE.test(cookie.value))
+			.map(cookie => `${cookie.name}=${cookie.value}`).join("; ");
+
+		if (!cookieString) {
+			await removeCookieRule(hostname);
+			return;
+		}
+
+		const id = cookieRuleIds.get(hostname) ?? nextCookieRuleId++;
+		cookieRuleIds.set(hostname, id);
+
+		try {
+		await browser.declarativeNetRequest.updateDynamicRules({
+			removeRuleIds: [id],
+			addRules: [{
+				"id": id,
 				"priority": 1,
 				"action": {
 					"type": "modifyHeaders",
@@ -128,18 +380,140 @@ async function DNRsetupCookies(hostname, storage) {
 					}]
 				},
 				"condition": {
-					"resourceTypes": ["media"]
+					"resourceTypes": ["media"],
+					// Same-site only: cookies are re-attached exclusively to
+					// media requests that both come from and go to this domain.
+					"initiatorDomains": [domain],
+					"requestDomains": [domain]
 				}
 			}]
 		});
+		}
+		catch (error) {
+			// e.g. cookie jar too large for a header rule: fail closed, the
+			// site simply behaves as if the workaround were off.
+			log("cookies rule install failed for", hostname, error);
+			cookieRuleIds.delete(hostname);
+			await browser.declarativeNetRequest.updateDynamicRules({removeRuleIds: [id]}).catch(() => {});
+			return;
+		}
 
-		console.log("Cookies DNR rule added for domain: ", hostname);
+		log("Scoped cookies rule updated for domain:", domain);
 	}
 	else {
-		await browser.declarativeNetRequest.updateDynamicRules({
-			removeRuleIds: [2]
-		});
+		await removeCookieRule(hostname);
 	}
 }
 
-getStorage().then(DNRsetupCORS);
+async function removeCookieRule(hostname) {
+	const id = cookieRuleIds.get(hostname);
+	if (id === undefined) return;
+	cookieRuleIds.delete(hostname);
+	await browser.declarativeNetRequest.updateDynamicRules({removeRuleIds: [id]}).catch(() => {});
+}
+
+async function removeAllCookieRules() {
+	const ids = Array.from(cookieRuleIds.values());
+	cookieRuleIds.clear();
+	if (ids.length) await browser.declarativeNetRequest.updateDynamicRules({removeRuleIds: ids}).catch(() => {});
+}
+
+/* Keep cookie rules fresh while the (optional) permission is granted, so
+   stale session cookies never linger in a rule after login/logout. */
+let cookieRefreshTimer = null;
+if (browser.cookies?.onChanged) {
+	browser.cookies.onChanged.addListener(() => {
+		clearTimeout(cookieRefreshTimer);
+		cookieRefreshTimer = setTimeout(async () => {
+			if (!await browser.permissions.contains({permissions: ["cookies"]})) return;
+			const storage = await getStorage();
+			for (const key of Object.keys(storage)) {
+				if (RESERVED_KEYS.has(key)) continue;
+				if (storage[key]?.sendCookiesInMediaRequests) {
+					await DNRsetupCookies(key, storage[key]);
+				}
+			}
+		}, 500);
+	});
+}
+
+/* ------------------------------------------------------------------ */
+/* STARTUP RECONCILIATION                                              */
+/*                                                                     */
+/* Dynamic DNR rules survive browser restarts and event-page wakes,    */
+/* but this script's in-memory bookkeeping does not. On every boot:    */
+/*  - CORS pair rules are re-associated to currently open tabs by      */
+/*    initiator hostname, and rules nobody needs any more (leftovers   */
+/*    from a previous session) are removed;                            */
+/*  - cookie rules are rebuilt for opted-in hosts, then stale rules    */
+/*    from previous boots are purged.                                  */
+/* ------------------------------------------------------------------ */
+const isCorsRule = r => r.action?.type === "modifyHeaders"
+	&& r.action?.responseHeaders?.[0]?.header === "Access-Control-Allow-Origin";
+const isCookieRule = r => r.action?.type === "modifyHeaders"
+	&& r.action?.requestHeaders?.[0]?.header === "Cookie";
+
+async function reconcileRules() {
+	const live = await browser.declarativeNetRequest.getDynamicRules().catch(() => []);
+
+	// Re-associate surviving CORS pair rules with live tabs.
+	const tabs = await browser.tabs.query({});
+	const tabsByHost = new Map();
+	for (const tab of tabs) {
+		const hostname = safeHostname(tab.url);
+		if (hostname) {
+			if (!tabsByHost.has(hostname)) tabsByHost.set(hostname, []);
+			tabsByHost.get(hostname).push(tab.id);
+		}
+	}
+
+	const removeIds = [];
+	for (const rule of live.filter(isCorsRule)) {
+		nextCorsRuleId = Math.max(nextCorsRuleId, rule.id + 1);
+		const initiator = rule.condition?.initiatorDomains?.[0];
+		const domain = rule.condition?.requestDomains?.[0];
+		const tabIds = (initiator != null && tabsByHost.get(initiator)) || [];
+
+		if (!isValidHostname(initiator) || !isValidHostname(domain) || tabIds.length === 0) {
+			removeIds.push(rule.id); // nobody needs it anymore
+			continue;
+		}
+
+		const key = `${initiator} -> ${domain}`;
+		corsRules.set(key, {id: rule.id, tabs: new Set(tabIds)});
+		for (const tabId of tabIds) {
+			if (!tabCorsKeys.has(tabId)) tabCorsKeys.set(tabId, new Set());
+			tabCorsKeys.get(tabId).add(key);
+			tabHostnames.set(tabId, initiator);
+		}
+	}
+	if (removeIds.length) {
+		await browser.declarativeNetRequest.updateDynamicRules({removeRuleIds: removeIds}).catch(() => {});
+		log("Startup: pruned orphaned CORS rules", removeIds);
+	}
+
+	// Remember which cookie-shaped rules existed before the rebuild so any
+	// stale one (from a previous boot) can be purged afterwards.
+	return live.filter(isCookieRule).map(rule => {
+		nextCookieRuleId = Math.max(nextCookieRuleId, rule.id + 1);
+		return rule.id;
+	});
+}
+
+getStorage().then(async storage => {
+	const preExistingCookieRules = await reconcileRules();
+
+	for (const key of Object.keys(storage)) {
+		if (RESERVED_KEYS.has(key)) continue;
+		if (storage[key]?.sendCookiesInMediaRequests) {
+			await DNRsetupCookies(key, storage[key]);
+		}
+	}
+
+	const freshIds = new Set(cookieRuleIds.values());
+	const staleIds = preExistingCookieRules.filter(id => !freshIds.has(id));
+	if (staleIds.length) {
+		await browser.declarativeNetRequest.updateDynamicRules({removeRuleIds: staleIds}).catch(() => {});
+		log("Startup: purged stale cookie rules", staleIds);
+	}
+});

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const DEBUG = false;
+const log = (...args) => { if (DEBUG) console.log(...args); };
 
 
 class AudioBooster {
@@ -22,7 +23,9 @@ class AudioBooster {
 		return this.gainNode.gain.value;
 	}
 	set gain(gain) {
-		this.gainNode.gain.value = gain;
+		// Short ramp instead of an instant jump: no audible pops/cracks when
+		// the multiplier changes mid-playback (kinder to ears and speakers).
+		this.gainNode.gain.setTargetAtTime(gain, this.audioCtx.currentTime, 0.05);
 	}
 
 	get mono() {
@@ -61,88 +64,205 @@ function onNodeCreation(callback, {type, selector} = {}) {
 
 
 (async () => {
-	// SENDING DOMAIN TO BACKGROUND SCRIPT + GETTING URL
-	let url, hostname, initialStorage;
+	// REGISTER THIS FRAME WITH THE BACKGROUND SCRIPT + GET SETTINGS
+	// (the background only shares the exclusion flag: minimal data flow)
+	let url, hostname, initialExcluded;
 	let messageIsResolved = false;
+
+	// The CORS rule must be scoped to THIS frame's real request initiator:
+	// its own origin for normal frames, or the inherited parent origin for
+	// about:blank frames - never the top hostname, or cross-origin iframes'
+	// media would get rules that never match their requests.
+	const frameInitiator = location.hostname || (() => {
+		try { return new URL(document.baseURI).hostname; } catch { return ""; }
+	})();
 
 	let message = browser.runtime.sendMessage({action: "updateRequests"}).then(response => {
 		url = response.url;
 		hostname = new URL(url).hostname;
-		initialStorage = response.storage;
+		initialExcluded = !!response.excluded;
 		messageIsResolved = true;
 
-		if (DEBUG) console.log("Domain: " + hostname);
+		log("Domain: " + hostname);
 	});
 
 
-	// SETTING UP STORAGE LISTENER TO UPDATE VOLUME MULTIPLIER
+	// VOLUME / MONO SYNC (the background computes the effective settings,
+	// which lets the temporary "session" multiplier live in RAM-only storage)
 	let audio = null;
 
 	async function updateVolume() {
-		if (audio) {
-			const storage = await getStorage(hostname);
-			const options = storage.session.url == url ? storage.session : storage[hostname];
+		if (!audio || !url) return;
 
-			audio.gain = options.volume / 100;
-			audio.mono = options.mono;
-		}
-	}
+		const effective = await browser.runtime.sendMessage({action: "getEffective", url}).catch(() => null);
+		if (!effective || effective.excluded) return;
 
-	function onStorageChange() {
-		if (DEBUG) console.log("Detected storage change");
-		updateVolume();
+		audio.gain = effective.volume / 100;
+		audio.mono = effective.mono;
 	}
-	browser.storage.local.onChanged.addListener(onStorageChange);
-	window.addEventListener("unload", () => {
-		browser.storage.local.onChanged.removeListener(onStorageChange)
-	}, {once: true});
 
 	browser.runtime.onMessage.addListener(message => {
 		if (message.action == "updateVolume") {
 			url = message.url;
-			if (DEBUG) console.log("Detected url change: " + url);
+			log("Detected url change: " + url);
 			updateVolume();
 		}
 	});
 
 
-	// WATCH FOR MEDIA ELEMENTS OR FINDING THEM IF THEY ALREADY EXIST
+	// PRIVACY HELPERS ----------------------------------------------------
+	// Report the cross-origin hosts this frame embeds media from, so the
+	// popup can offer *scoped* host permissions (same-origin media never
+	// needs any permission and is never reported).
+	function reportMediaSources(elements) {
+		const hostnames = [];
+
+		for (let el of elements) {
+			try {
+				const sourceUrl = new URL(el.currentSrc ?? el.src, document.baseURI);
+				if ((sourceUrl.protocol == "http:" || sourceUrl.protocol == "https:") && sourceUrl.origin != location.origin) {
+					hostnames.push(sourceUrl.hostname);
+				}
+			} catch {}
+		}
+
+		if (hostnames.length) {
+			browser.runtime.sendMessage({action: "reportMediaSources", hostnames}).catch(() => {});
+		}
+	}
+
+	// Ask the background for a CORS relaxation scoped to
+	// (this page -> that media domain) instead of a global one.
+	async function requestScopedCors(mediaHostname) {
+		const response = await browser.runtime.sendMessage({
+			action: "ensureCors",
+			initiator: frameInitiator,
+			domain: mediaHostname
+		}).catch(() => null);
+
+		return !!response?.ok;
+	}
+
+	function getCrossOriginMediaHostname(el, useAttribute = false) {
+		try {
+			// useAttribute: during a src-swap mutation, currentSrc still
+			// points at the OLD resource - the attribute holds the new one.
+			// Otherwise also consider <source> children: elements that carry
+			// their URL in a child keep el.src/currentSrc empty until the
+			// resource selection runs.
+			let raw;
+			if (useAttribute) raw = el.getAttribute("src") ?? "";
+			else {
+				raw = el.currentSrc || el.src || "";
+				if (!raw && el.querySelector) {
+					const source = el.querySelector("source");
+					if (source) raw = source.getAttribute("src") ?? "";
+				}
+			}
+			const sourceUrl = new URL(raw, document.baseURI);
+			if ((sourceUrl.protocol == "http:" || sourceUrl.protocol == "https:") && sourceUrl.origin != location.origin) {
+				return sourceUrl.hostname;
+			}
+		} catch {}
+		return null;
+	}
+
+
+	// WATCH FOR MEDIA ELEMENTS OR FIND THEM IF THEY ALREADY EXIST ---------
+	const connected = new WeakSet(); // elements already wired to the booster
+
 	async function onMediaElementCreation(el) {
+		// iframes are only observed to report their host for the popup's
+		// permission prompt (their own content script instance boosts them).
+		if (el.tagName == "IFRAME") {
+			reportMediaSources([el]);
+			return;
+		}
+
+		// <source> children can arrive in a later mutation than their media
+		// element; (re)apply the cross-origin setup to a not-yet-connected
+		// parent so <source>-based cross-origin media is boosted, not muted.
+		if (el.tagName == "SOURCE") {
+			const parent = el.parentElement;
+			if (parent && (parent.tagName == "VIDEO" || parent.tagName == "AUDIO") && !connected.has(parent)) {
+				const host = getCrossOriginMediaHostname(parent);
+				if (host) {
+					requestScopedCors(host).then(ok => {
+						if (ok && parent.isConnected && !connected.has(parent)) {
+							parent.crossOrigin = "anonymous";
+							parent.load();
+						}
+					}).catch(() => {});
+				}
+			}
+			return;
+		}
+
 		const BOOSTED_CLASSNAME = `_volume-boosted`;
 
 		if (!el.classList.contains(BOOSTED_CLASSNAME)) {
-			if (DEBUG) console.log(el);
+			log(el);
 
 			el.classList.add(BOOSTED_CLASSNAME);
+			reportMediaSources([el]);
 
 			if (messageIsResolved) {
-				if (DEBUG) console.log("Message already resolved, could cleanly bypass")
+				log("Message already resolved, could cleanly bypass");
 
-				if (initialStorage[hostname].excluded) {
+				if (initialExcluded) {
 					return;
 				}
-
-				el.crossOrigin = "anonymous";
 			}
 			else {
-				if (DEBUG) console.log("Message not yet resolved, had to reload media element")
+				log("Message not yet resolved, had to reload media element");
 
 				el.preload = "metadata";
 
 				await message;
 
-				if (initialStorage[hostname].excluded) {
+				if (initialExcluded) {
 					el.load();
 					return;
 				}
+			}
+
+			// Same-origin media needs no CORS relaxation and no request
+			// modification at all: it is left completely untouched.
+			// Cross-origin media gets a scoped (page -> media host) rule,
+			// requested before the (re)fetch so the response carries CORS.
+			const mediaHostname = getCrossOriginMediaHostname(el);
+			if (mediaHostname) {
+				const allowed = await requestScopedCors(mediaHostname);
+				if (!allowed) return;
 
 				el.crossOrigin = "anonymous";
 
+				// (Re)start the fetch now that the scoped rule exists, so the
+				// very first request already carries CORS: no race with the
+				// resource-selection task, and no tainted (silenced) media.
 				el.load();
 			}
 
+			// If the player later swaps the source to another cross-origin
+			// host, request the new scoped rule on attribute change and then
+			// restart the fetch once the rule is active (the implicit load
+			// that races ahead without CORS is simply retried).
+			new MutationObserver(() => {
+				const swappedHost = getCrossOriginMediaHostname(el, true);
+				if (swappedHost) {
+					el.crossOrigin = "anonymous";
+					requestScopedCors(swappedHost).then(ok => {
+						if (ok && el.isConnected) el.load();
+					}).catch(() => {});
+				}
+			}).observe(el, {attributes: true, attributeFilter: ["src"]});
+
 			if (el.paused) {
-				await new Promise(resolve => el.addEventListener("play", resolve, {once: true}));
+				const failed = await new Promise(resolve => {
+					el.addEventListener("play", () => resolve(false), {once: true});
+					el.addEventListener("error", () => resolve(true), {once: true});
+				});
+				if (failed) return;
 			}
 
 			if (!audio) {
@@ -150,20 +270,41 @@ function onNodeCreation(callback, {type, selector} = {}) {
 				updateVolume();
 			}
 
-			audio.connectMediaElement(el);
+			// The page may already own this element's WebAudio graph (only one
+			// MediaElementSource per element is allowed): in that case leave
+			// the page's audio completely alone instead of throwing.
+			try {
+				audio.connectMediaElement(el);
+				connected.add(el);
+			}
+			catch (error) {
+				log("Could not connect media element (page owns its WebAudio graph?):", error);
+				return;
+			}
 		}
 	}
 
-	const MEDIA_TAGS_SELECTOR = "video, audio";
+	const MEDIA_TAGS_SELECTOR = "video, audio, iframe, source";
 	onNodeCreation(onMediaElementCreation, {type: Node.ELEMENT_NODE, selector: MEDIA_TAGS_SELECTOR})
-	document.querySelectorAll(MEDIA_TAGS_SELECTOR).forEach(onMediaElementCreation);
+
+	function initialScan() {
+		const found = document.querySelectorAll(MEDIA_TAGS_SELECTOR);
+		reportMediaSources(found);
+		found.forEach(onMediaElementCreation);
+	}
+	initialScan();
+	if (document.readyState == "loading") {
+		document.addEventListener("DOMContentLoaded", initialScan, {once: true});
+	}
 
 
 	// RESUME AUDIO CONTEXT ON FIRST USER INTERACTION
-	document.addEventListener("click", () => {
+	const resumeAudio = () => {
 		if (audio && audio.audioCtx.state === "suspended") {
 			audio.audioCtx.resume();
-			if (DEBUG) console.log("Resumed AudioContext");
+			log("Resumed AudioContext");
 		}
-	}, {once: true});
+	};
+	document.addEventListener("click", resumeAudio, {once: true});
+	document.addEventListener("keydown", resumeAudio, {once: true});
 })();

--- a/scripts/options.js
+++ b/scripts/options.js
@@ -11,6 +11,8 @@ const SPECIFY_PERMISSION_SUBDOMAINS_CHECKBOX = document.getElementById("specify-
 const APPLY_DEFAULT_LOCAL_SETTINGS_CHECKBOX = document.getElementById("apply-default-local-settings-checkbox");
 const MORE_INFORMATION_BUTTON = document.getElementById("more-information-button");
 const RESET_STORAGE_BUTTON = document.getElementById("reset-storage-button");
+const CLEAR_SITE_DATA_BUTTON = document.getElementById("clear-site-data-button");
+const COOKIES_PERMISSION_STATUS = document.getElementById("cookies-permission-status");
 
 
 (async () => {
@@ -25,7 +27,22 @@ const RESET_STORAGE_BUTTON = document.getElementById("reset-storage-button");
 	SHOW_AUDIO_CHANNEL_BUTTONS_CHECKBOX.checked = storage.options.showAudioChannelButtons;
 	SPECIFY_PERMISSION_SUBDOMAINS_CHECKBOX.checked = storage.options.specifyPermissionSubdomains;
 	APPLY_DEFAULT_LOCAL_SETTINGS_CHECKBOX.checked = storage.options.applyDefaultLocalSettings;
+
+	await refreshCookiesPermissionStatus();
+
+	// opened from the background when a cookies-permission request couldn't run
+	if (location.hash == "#cookies-permission") {
+		alert("The optional \"cookies\" permission could not be requested from the context menu.\nYou can grant it from here by enabling \"Send cookies to media requests\" for a site via the toolbar icon's right-click menu; Firefox will then ask for the permission.");
+	}
 })();
+
+async function refreshCookiesPermissionStatus() {
+	if (!COOKIES_PERMISSION_STATUS) return;
+	const granted = await browser.permissions.contains({permissions: ["cookies"]});
+	COOKIES_PERMISSION_STATUS.textContent = granted ? "granted" : "not granted (the feature asks for it when you enable it per-site)";
+}
+browser.permissions.onAdded.addListener(refreshCookiesPermissionStatus);
+browser.permissions.onRemoved.addListener(refreshCookiesPermissionStatus);
 
 
 const setOptions = properties => setStorage({ options: { ...properties } })
@@ -50,9 +67,18 @@ That being said, this extension offers some workarounds to fix most websites, bu
 If you have any questions about the options, feel free to open an issue on github and ask me.`)
 })
 
+CLEAR_SITE_DATA_BUTTON.addEventListener("click", async () => {
+	if (confirm("Forget every per-site setting (volumes, exclusions, cookie exceptions)?\nGlobal options and the global volume are kept.")) {
+		const storage = await browser.storage.local.get();
+		const siteKeys = Object.keys(storage).filter(key => !RESERVED_KEYS.has(key));
+		if (siteKeys.length) await browser.storage.local.remove(siteKeys);
+	}
+})
+
 RESET_STORAGE_BUTTON.addEventListener("click", async () => {
 	if (confirm("Are you sure you want to clear all settings and reset them to default?")) {
 		await browser.storage.local.clear()
+		if (browser.storage.session) await browser.storage.session.clear().catch(() => {});
 		browser.runtime.reload()
 	}
 })

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -115,46 +115,23 @@ async function initPopup() {
 
 
 async function promptMediaSourcesHostnames(includeSubdomains) {
+	// No scripting permission needed: every frame's content script already
+	// reports the cross-origin media hosts it embeds to the background, and
+	// that in-memory list is what we display here. The content script may
+	// still be booting when the popup opens on a fresh page, so retry once.
 	async function getMediaSourcesHostnames() {
-		let mediaSourcesResult = await browser.scripting.executeScript({
-			target: {tabId: currentTabId, allFrames: true},
-			/* injectImmediately: true, */
-			func: () => {
-				let sourceHostnames = [];
-
-				const foundElements = document.querySelectorAll("video, audio, iframe");
-
-				for (let el of foundElements) {
-					try {
-						let hostname = new URL(new URL(el.currentSrc ?? el.src).origin).hostname;
-						sourceHostnames.push(hostname);
-					}
-					catch {}
-				}
-
-				return sourceHostnames;
-			}
-		})
-
-		return mediaSourcesResult.map(res => res.result).flat().filter(el => el);
-	}
-	function getEssentialHostnames(arr, includeSubdomains=true) {
-		if (!includeSubdomains) {
-			arr = arr.map(hostname => hostname.split(".").slice(-2).join("."));
+		const query = async () => {
+			const response = await browser.runtime.sendMessage({action: "getMediaSources", tabId: currentTabId}).catch(() => null);
+			return response?.hostnames ?? [];
+		};
+		let hostnames = await query();
+		if (!hostnames.length) {
+			await new Promise(resolve => setTimeout(resolve, 400));
+			hostnames = await query();
 		}
-
-		let set = new Set(arr);
-
-		for (let hostname of set) {
-			for (let hostname2 of set) {
-				if (hostname.includes(hostname2) && hostname !== hostname2) {
-					set.delete(hostname);
-				}
-			}
-		}
-
-		return Array.from(set);
+		return hostnames;
 	}
+	// getEssentialHostnames comes from utils.js (true subdomain logic)
 	async function getNeededHostnames(arr) {
 		let isGrantedHostname = hostname => browser.permissions.contains({ origins: [`*://*.${hostname}/*`] });
 
@@ -188,8 +165,9 @@ async function promptMediaSourcesHostnames(includeSubdomains) {
 		const mediaSourcesHostnames = await getMediaSourcesHostnames();
 
 		if (mediaSourcesHostnames.length > 0) {
-			// get the essential hostnames (no duplicates, no subdomains, etc.)
-			const mediaSourcesEssential = getEssentialHostnames([currentHostname, ...mediaSourcesHostnames], includeSubdomains);
+			// Only hosts that actually serve cross-origin media are offered:
+			// the extension never asks for more access than it needs.
+			const mediaSourcesEssential = getEssentialHostnames(mediaSourcesHostnames, includeSubdomains);
 
 			// get the hostnames that don't already have permissions
 			const mediaSourcesNeeded = await getNeededHostnames(mediaSourcesEssential);
@@ -204,7 +182,7 @@ async function promptMediaSourcesHostnames(includeSubdomains) {
 			}
 		}
 		else {
-			// if there are no media elements in the page, show the message
+			// if there is no cross-origin media in the page, show the message
 			NO_MEDIA_DETECTED_MESSAGE.classList.remove("hidden");
 		}
 	}
@@ -324,6 +302,11 @@ ASK_PERMISSIONS_BUTTON.addEventListener("click", async () => {
 	for (let chkbox of document.getElementsByClassName("media-source-checkbox")) {
 		if (chkbox.checked) {
 			mediaSources.push(`*://*.${chkbox.name}/*`);
+			// "*://*.example.com/*" does not match "example.com" itself, so
+			// bare registrable domains also get their exact-origin pattern.
+			if (registrableDomain(chkbox.name) === chkbox.name) {
+				mediaSources.push(`*://${chkbox.name}/*`);
+			}
 		}
 	}
 
@@ -334,6 +317,7 @@ ASK_PERMISSIONS_BUTTON.addEventListener("click", async () => {
 })
 
 ENABLE_ALL_PERMISSIONS_BUTTON.addEventListener("click", async () => {
+	if (!confirm("Grant the extension data access to ALL websites?\nOnly do this if you trust every site's media to be readable by this extension.")) return;
 	let granted = await browser.permissions.request({ origins: ["<all_urls>"] })
 	if (granted) browser.tabs.reload(currentTabId);
 });

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,5 +1,60 @@
 "use strict";
 
+/* Keys that are not per-site data (used e.g. by the "forget per-site settings" button). */
+const RESERVED_KEYS = new Set(["options", "global", "session"]);
+
+/* Hostname sanity check: anything that fails this never reaches a DNR rule. */
+function isValidHostname(hostname) {
+	return typeof hostname === "string"
+		&& hostname.length > 0 && hostname.length <= 253
+		&& /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/i.test(hostname);
+}
+
+/* Common multi-part public suffixes so registrable domains stay correct for
+   e.g. *.co.uk / *.com.au hosts (cookie scoping depends on this). */
+const TWO_LEVEL_SUFFIXES = new Set([
+	"co.uk", "org.uk", "ac.uk", "gov.uk", "me.uk", "net.uk",
+	"com.au", "net.au", "org.au", "edu.au", "asn.au",
+	"co.nz", "net.nz", "org.nz", "govt.nz",
+	"co.jp", "ne.jp", "or.jp", "ac.jp", "ad.jp",
+	"com.br", "net.br", "org.br", "com.ar", "com.mx", "com.tr",
+	"com.pl", "co.za", "co.in", "net.in", "org.in", "com.sg",
+	"com.hk", "com.tw", "co.kr", "com.cn", "net.cn", "org.cn",
+	"gov.cn", "co.il", "org.il", "net.il", "co.cr", "com.co",
+	"com.ve", "com.eg", "co.ke", "com.ua", "com.vn", "co.th"
+]);
+
+function registrableDomain(hostname) {
+	hostname = String(hostname).toLowerCase();
+	if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) return hostname; // IPv4 literal
+	const parts = hostname.split(".").filter(Boolean);
+	if (parts.length <= 2) return parts.join(".");
+	const lastTwo = parts.slice(-2).join(".");
+	if (TWO_LEVEL_SUFFIXES.has(lastTwo)) return parts.slice(-3).join(".");
+	return lastTwo;
+}
+
+/* Reduces a hostname list to the minimal covering set: a hostname is dropped
+   only when another entry is its exact parent domain (true subdomain relation,
+   not mere substring matching like "evilsite.com" ~ "site.com"). */
+function getEssentialHostnames(arr, includeSubdomains = true) {
+	let set = new Set(arr.filter(isValidHostname));
+
+	if (!includeSubdomains) {
+		set = new Set(Array.from(set, registrableDomain));
+	}
+
+	for (let hostname of [...set]) {
+		for (let parent of [...set]) {
+			if (hostname !== parent && hostname.endsWith("." + parent)) {
+				set.delete(hostname);
+			}
+		}
+	}
+
+	return Array.from(set);
+}
+
 async function getStorage(targetHostname=null) {
 	const DEFAULT_GLOBAL_SETTINGS = {
 		options: {
@@ -42,10 +97,29 @@ async function getStorage(targetHostname=null) {
 
 	let storage = await browser.storage.local.get()
 
+	// v1.16: the temporary "session" multiplier moved from disk (storage.local)
+	// to RAM-only storage.session, so it truly dies with the browser session.
+	{
+		const legacySession = storage.session;
+		delete storage.session;
+
+		let sessionStore = {};
+		if (browser.storage.session) {
+			try { sessionStore = await browser.storage.session.get("session"); } catch {}
+		}
+		storage.session = {...DEFAULT_GLOBAL_SETTINGS.session, ...(sessionStore.session ?? {}), ...(legacySession ?? {})};
+
+		if (legacySession && browser.storage.session) {
+			browser.storage.session.set({session: storage.session})
+				.then(() => browser.storage.local.remove("session"))
+				.catch(() => {});
+		}
+	}
+
 	// backwards compatibility for v1.13
 	{
 		for (let key in storage) {
-			if (storage[key].volumeMultiplierPercent) {
+			if (storage[key] && storage[key].volumeMultiplierPercent) {
 				storage[key].volume ??= storage[key].volumeMultiplierPercent;
 			}
 		}
@@ -62,7 +136,7 @@ async function getStorage(targetHostname=null) {
 	function deleteUndefinedKeys(obj) {
 		for (let key in obj) {
 			if (obj[key] === undefined) delete obj[key];
-			else if (typeof obj[key] === "object") deleteUndefinedKeys(obj[key]);
+			else if (typeof obj[key] === "object" && obj[key]) deleteUndefinedKeys(obj[key]);
 		}
 	}
 	deleteUndefinedKeys(storage);
@@ -77,24 +151,61 @@ async function getStorage(targetHostname=null) {
 		}
 	}
 
-	if (targetHostname) {
+	if (targetHostname != null) {
 		const hostnameStorage = {...DEFAULT_LOCAL_GENERAL_SETTINGS, ...storage[targetHostname]}
 
 		if (hostnameStorage.enabled) storage[targetHostname] = hostnameStorage;
 		else storage[targetHostname] = {...hostnameStorage, ...storage.global}
 	}
 
+	// The hard limit is a safety feature: clamp every effective volume to it,
+	// including values stored before the limit was lowered.
+	{
+		const limit = storage.options.volumeMultiplierPercentLimit;
+		const clamp = o => { if (o && typeof o.volume === "number") o.volume = Math.min(Math.max(o.volume, 0), limit); };
+		clamp(storage.global);
+		clamp(storage.session);
+		if (targetHostname != null) clamp(storage[targetHostname]);
+	}
+
 	return storage;
 }
 
+/* Deep-merges `src` into `target`; keys set to `undefined` are deleted. */
+function deepMerge(target, src) {
+	const out = {...(target ?? {})};
+	for (let key in src) {
+		const value = src[key];
+		if (value === undefined) delete out[key];
+		else if (value && typeof value === "object" && !Array.isArray(value) && out[key] && typeof out[key] === "object") out[key] = deepMerge(out[key], value);
+		else out[key] = value;
+	}
+	return out;
+}
+
 async function setStorage(obj) {
-	let storage = await browser.storage.local.get(Object.keys(obj));
+	const localObj = {};
 
 	for (let key in obj) {
-		storage[key] = {...storage[key], ...obj[key]}
+		if (key === "session") {
+			// Session data is RAM-only: never written to disk.
+			if (browser.storage.session) {
+				const current = (await browser.storage.session.get("session")).session ?? {};
+				await browser.storage.session.set({session: deepMerge(current, obj.session)});
+			}
+		}
+		else localObj[key] = obj[key];
 	}
 
-	return browser.storage.local.set(storage);
+	if (Object.keys(localObj).length) {
+		let storage = await browser.storage.local.get(Object.keys(localObj));
+
+		for (let key in localObj) {
+			storage[key] = deepMerge(storage[key], localObj[key]);
+		}
+
+		return browser.storage.local.set(storage);
+	}
 }
 
 class VolumeOptions {


### PR DESCRIPTION
## Summary

Rework of the extension's `declarativeNetRequest` usage and permission model (v1.15.2 → v1.23.0). Every existing feature is kept intact: global/local/session volume multipliers, mono/stereo buttons, the hard-limit option, per-subdomain context-menu options, the permission prompt flow, and the remember-everything behaviour. The add-on ID and storage schema are unchanged, so this installs as a seamless update (existing settings are kept; on-disk session values are migrated automatically).

## Resolves the review findings

> **Security header modification:** Relaxing security headers (including a CSP) of a website is not permitted. — `scripts/background.js:95`

The rule that set `Access-Control-Allow-Origin: *` on **every** media response on the web is gone. The only remaining ACAO modification is scoped to the exact (initiator frame → media host) pair with `resourceTypes: ["media"]`, created on demand and removed when the last tab needing it closes or navigates; startup reconciliation prunes orphans after restarts/wakes. No CSP header is modified anywhere. The scoped relaxation is the minimum technically required for the core feature (WebAudio cannot process cross-origin media without CORS on those responses); end-to-end tests show page scripts cannot `fetch()`/exfiltrate the bytes and hosts the page doesn't embed receive no relaxation.

> **Other security issue:** Declarative net request rule may result in cross-domain cookie transmission. — `scripts/background.js:117`

The cookie rule now requires `initiatorDomains` **and** `requestDomains` of the same (public-suffix-aware) registrable domain, plus `resourceTypes: ["media"]` — cookies can only ever be re-attached same-site, so cross-domain transmission is impossible by construction. Additionally: values are filtered to RFC 6265 cookie-octets (no header injection), the `cookies` permission is now **optional** and requested per-site on a user gesture, the workaround is limited to the default container (no Multi-Account Container leakage), and rules refresh on cookie change and purge on revocation/restart.

## Other highlights

- Removed the `scripting` permission (the popup no longer injects code into pages; frames self-report cross-origin media hosts); `<all_urls>` stays optional.
- Strict CSP on extension pages; hostnames validated before reaching any rule; content scripts receive only `{url, excluded}` instead of the whole settings object.
- Session multiplier moved to RAM-only `storage.session`.
- Correctness without breaking sites: cross-origin iframes, `<source>`-child media, mid-session `src` swaps, `file://` pages, errored media, and pages that own their WebAudio graph are all handled.
- UX: the permission prompt lists only hosts that actually need access; "enable for all websites" now asks for confirmation.
- `CHANGELOG.md` documents v1.16.0–v1.23.0 in the original format; `README.md` gained Privacy and Testing sections.

## Testing

- `addons-linter`: 0 errors, 0 warnings.
- 35 Node unit tests against a mocked WebExtension API (rule lifecycles, scoping, validation, containers, clamping).
- 12 jsdom tests covering popup/options wiring (sliders, session logic, permission origins, reset flows).
- 17 end-to-end checks in a real Firefox 140 ESR via Marionette (boosting, scoped-CORS behaviour, iframes/sources/swaps, restart reconciliation).
